### PR TITLE
don't install an optional dev-dependency if it already exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,15 @@ module.exports = function (packages, _options, cb) {
   }, _options)
 
   async.eachLimit(packages, 1, function (pkg, next) {
-    var child = spawn('npm', ['install', pkg], {stdio: options.stdio})
-    child.on('close', function () {
+    try {
+      require(pkg)
       return next()
-    })
+    } catch (err) {
+      var child = spawn('npm', ['install', pkg], {stdio: options.stdio})
+      child.on('close', function () {
+        return next()
+      })
+    }
   }, function (err) {
     return cb(err)
   })

--- a/test/optional-dev-dependency.js
+++ b/test/optional-dev-dependency.js
@@ -39,4 +39,16 @@ describe('optional-dev-dependency', function () {
       return done()
     })
   })
+
+  it('does not install a dependency if it already exists', function (done) {
+    var delta = 25
+    optionalDevDependency(['camelcase'], {stdio: null}, function () {
+      var start = (new Date()).getTime()
+      optionalDevDependency(['camelcase'], {stdio: null}, function () {
+        var stop = (new Date()).getTime()
+        ;(stop - start).should.be.lt(delta)
+        return done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
adds tests to @BridgeAR's work in: https://github.com/bcoe/optional-dev-dependency/pull/3
