### PR TITLE
Use require.resolve instead of require to avoid executing code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ module.exports = function (packages, _options, cb) {
   }, _options)
 
   async.eachLimit(packages, 1, function (arg, next) {
-    var pkg = arg.substr(0, arg.indexOf('@')) || arg
+    var pkg = arg.split('@')[0]
     try {
       // TODO: Either skip this part if a version has been provided or check the package json version
-      require(pkg)
+      require.resolve(pkg)
       return next()
     } catch (err) {
       var child = spawn('npm', ['install', arg], {stdio: options.stdio})


### PR DESCRIPTION
Use `require.resolve` instead of `require` to avoid executing the package code.
