### PR TITLE
Save dependencies.  Fixes #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
-node_modules
-.nyc_output
+node_modules/
+.nyc_output/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "iojs"
+  - "4"
+  - "5"
+  - "6"
 after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,32 @@ optional-dev-dependency lodash redis@2.2.3 fffffffgggggg
 
 All different [npm install styles](https://docs.npmjs.com/cli/install) are supported besides the git remote url
 
-## Example
+## Command Line
+
+```
+optional-dev-dependency package [options]
+
+Options:
+  -s, --silent   should the `npm install` output be shown?
+                                                      [boolean] [default: false]
+  -S, --save     try to install the specified packages, and save them to
+                 optionalDevDependencies in package.json
+                                                      [boolean] [default: false]
+  -t, --tag      only try to load dependencies with this tag
+  -V, --verbose  output NPM commands before running them
+                                                      [boolean] [default: false]
+  -h, --help     Show help                                             [boolean]
+  -v, --version  Show version number                                   [boolean]
+
+Examples:
+  ../bin/odd.js lodash hiredis  try to install 'lodash' and 'hiredis', it's okay
+                                if an install fails.
+  ../bin/odd.js -t travis       try to install optionalDevDependencies for the
+                                'travis' tag from package.json, it's okay if an
+                                install fails.
+```
+
+## Examples
 
 Here's an example from `node_redis`:
 
@@ -25,6 +50,48 @@ Here's an example from `node_redis`:
     "pretest": "optional-dev-dependency hiredis"
   }
 }
+```
+
+You can also save optionalDevDependencies in your `package.json` file for ease
+of installation later.  For example, let's say you want most developers who
+download your package and play with it to run basic tests, but when you run your
+code on your continuous integration server, you need a few extra dependencies.
+You can use a `package.json` file like this:
+
+```json
+{
+  "name": "sample",
+  "scripts": {
+    "test": "mocha",
+    "precoverage": "optional-dev-dependency",
+    "coverage": "nyc npm test",
+    "preci": "optional-dev-dependency -t ci",
+    "ci": "nyc report --reporter=text-lcov | coveralls"
+  },
+  "optionalDevDependencies": {
+    "nyc": "^8.3.1",
+    "coveralls": [
+      "^2.11.14",
+      "ci"
+    ]
+  }
+}
+```
+
+When you do `npm run coverage`, the `precoverage` script will ensure that all
+optionalDevDependencies without a tag are installed (in this case, `nyc`).
+
+When you do `npm run ci` on your CI server, the `preci` script will ensure that
+all optionalDevDependencies with the `ci` tag are installed (in this case,
+`coveralls`).
+
+You can load optionalDevDependencies into your `package.json` with the
+--save/-S flag.  This will install the latest lodash, save that version
+in your `package.json`, and will only install it later if the `foo` or `bar`
+tag is specified:
+
+```shell
+optional-dev-dependency --save lodash -t foo -t bar
 ```
 
 ## License

--- a/bin/odd.js
+++ b/bin/odd.js
@@ -6,22 +6,59 @@ var yargs = require('yargs')
   .usage('$0 package [options]')
   .option('s', {
     alias: 'silent',
+    boolean: true,
     default: false,
     describe: 'should the `npm install` output be shown?'
   })
+  .option('S', {
+    alias: 'save',
+    boolean: true,
+    default: false,
+    describe: 'try to install the specified packages, and save them to optionalDevDependencies in package.json'
+  })
+  .option('t', {
+    alias: 'tag',
+    describe: 'only try to load dependencies with this tag'
+  })
+  .option('V', {
+    alias: 'verbose',
+    boolean: true,
+    default: false,
+    describe: 'output NPM commands before running them'
+  })
   .example('$0 lodash hiredis', "try to install 'lodash' and 'hiredis', it's okay if an install fails.")
+  .example('$0 -t travis', "try to install optionalDevDependencies for the 'travis' tag from package.json, it's okay if an install fails.")
   .alias('h', 'help')
-  .version(require('../package').version, 'v')
+  .version()
   .alias('v', 'version')
   .help('h')
 var argv = yargs.argv
 var optionalDevDependency = require('../')
 
-if (argv._.length === 0) {
-  yargs.showHelp()
-} else {
-  optionalDevDependency(argv._, {
-    stdio: argv.silent ? null : 'inherit',
-    concurrency: argv.concurrency
-  })
+var opts = {
+  stdio: argv.silent ? null : 'inherit',
+  tags: (typeof argv.tag === 'string') ? [argv.tag] : argv.tag,
+  verbose: argv.verbose
 }
+
+if (argv._.length === 0) {
+  try {
+    argv._ = optionalDevDependency.readPackage().optionalDevDependencies
+    if (!argv._ || Object.keys(argv._).length < 1) {
+      yargs.showHelp()
+      process.exit(64)
+    } else {
+      optionalDevDependency(argv._, opts)
+    }
+  } catch (e) {
+    console.error(e.message)
+    process.exit(1)
+  }
+} else if (argv.save) {
+  optionalDevDependency.saveAll(argv._, opts, function () {
+    optionalDevDependency(argv._, opts)
+  })
+} else {
+  optionalDevDependency(argv._, opts)
+}
+

--- a/bin/odd.js
+++ b/bin/odd.js
@@ -42,18 +42,19 @@ var opts = {
 }
 
 if (argv._.length === 0) {
-  try {
-    argv._ = optionalDevDependency.readPackage().optionalDevDependencies
+  optionalDevDependency.readPackage((er, pkg) => {
+    if (er) {
+      console.error(e.message)
+      process.exit(1)
+    }
+    argv._ = pkg.optionalDevDependencies
     if (!argv._ || Object.keys(argv._).length < 1) {
       yargs.showHelp()
       process.exit(64)
     } else {
       optionalDevDependency(argv._, opts)
     }
-  } catch (e) {
-    console.error(e.message)
-    process.exit(1)
-  }
+  })
 } else if (argv.save) {
   optionalDevDependency.saveAll(argv._, opts, function () {
     optionalDevDependency(argv._, opts)

--- a/bin/odd.js
+++ b/bin/odd.js
@@ -44,7 +44,7 @@ var opts = {
 if (argv._.length === 0) {
   optionalDevDependency.readPackage((er, pkg) => {
     if (er) {
-      console.error(e.message)
+      console.error(er.message)
       process.exit(1)
     }
     argv._ = pkg.optionalDevDependencies

--- a/dependency.js
+++ b/dependency.js
@@ -1,0 +1,161 @@
+'use strict'
+
+const spawn = require('cross-spawn')
+const path = require('path')
+const fs = require('fs')
+
+class Dependency {
+  // name could be 'foo', or 'foo@1' (if ver is null).
+  // ver is an array of [ver, tag, ...]
+  constructor (name, version) {
+    if (typeof name !== 'string') {
+      throw new TypeError('name must be string')
+    }
+    if (version == null) {
+      const parts = name.split('@')
+      this.name = parts[0]
+      this.version = (parts.length > 1) ? parts[1] : '*'
+      this.tags = []
+    } else {
+      this.name = name
+      this.tags = Dependency.toArray(version)
+      this.version = this.tags.shift()
+    }
+  }
+
+  get nameAtVersion () {
+    if (!this.version || (this.version === '*') || (this.version === 'latest')) {
+      return this.name
+    }
+    return this.name + '@' + this.version
+  }
+
+  getVersion (options, cb) {
+    if (typeof options === 'function') {
+      cb = options
+      options = { verbose: false }
+    }
+    const child = spawn('npm', ['info', this.name, 'version'], {
+      stdio: ['ignore', 'pipe', 'inherit']
+    })
+    const data = []
+    child.stdout.on('data', function (buf) { data.push(buf) })
+    child.once('error', cb)
+    child.once('close', () => {
+      this.version = '^' + Buffer.concat(data).toString('utf8').replace(/\n$/, '')
+      if (options.verbose) {
+        console.error('npm info ' + this.name + ' version: ' + this.version)
+      }
+      cb(null, this.version)
+    })
+  }
+
+  addTags (tags) {
+    tags = Dependency.toArray(tags)
+    if (tags.length > 0) {
+      for (const tag of Dependency.toArray(tags)) {
+        if (this.tags.indexOf(tag) === -1) {
+          this.tags.push(tag)
+        }
+      }
+    }
+    return this.tags
+  }
+
+  // is there a tag in list that is in tags, or does list have '*' in it?
+  isInTags (list) {
+    if ((this.tags.length === 0) || (this.tags.indexOf('*') > -1)) {
+      return '*'
+    }
+    list = Dependency.toArray(list)
+    for (var i = 0; i < list.length; i++) {
+      if (this.tags.indexOf(list[i]) > -1) {
+        return list[i]
+      }
+    }
+    return null
+  }
+
+  isInstalled () {
+    try {
+      const dir = path.join(Dependency.findNodeModules(), this.name)
+      require.resolve(path.join(dir))
+      return true
+    } catch (e) {
+      return false
+    }
+  }
+
+  install (options, cb) {
+    if (typeof options === 'function') {
+      cb = options
+      options = {}
+    }
+    const nav = this.nameAtVersion
+    if (options.verbose) {
+      console.error('npm install ' + nav)
+    }
+    const child = spawn('npm', ['install', nav], {stdio: options.stdio})
+    child.once('error', (er) => {
+      if (options.verbose) {
+        console.error('Error installing', er.message)
+      }
+      cb()
+    })
+    child.once('close', (code) => {
+      if (code !== 0) {
+        if (options.verbose) {
+          console.error('Error installing', nav, 'code', code, 'stdio', options.stdio)
+        }
+      }
+      cb()
+    })
+  }
+
+  toJSON () {
+    const ver = this.version || '*'
+    if (this.tags.length > 0) {
+      return [ver].concat(this.tags)
+    }
+    return ver
+  }
+
+  static toArray (stringOrArray) {
+    if (!stringOrArray) {
+      return []
+    }
+    if (typeof stringOrArray === 'string') {
+      return [stringOrArray]
+    } else if (Array.isArray(stringOrArray)) {
+      return stringOrArray
+    }
+    throw new TypeError('invalid input not string or array' + stringOrArray)
+  }
+
+  // Search up the path, starting at cwd, looking for node_modules
+  // Note: require works off of the path of *this* module by default, not
+  // from process.cwd().  Find the correct node_modules directory from cwd,
+  // and use absolute paths to load from that directory.
+  static findNodeModules (filename) {
+    filename = filename || 'node_modules'
+    if (Dependency.__root) {
+      return path.join(Dependency.__root, filename)
+    }
+    let parts = process.cwd().split(path.sep)
+    while (parts.length > 1) {
+      Dependency.__root = path.sep + path.join.apply(path, parts)
+      if (fs.existsSync(path.join(Dependency.__root, 'package.json'))) {
+        return path.join(Dependency.__root, filename)
+      }
+      parts.pop()
+    }
+    Dependency.clear()
+    throw new Error('Not in a node package hierarchy')
+  }
+
+  // Clear the cache of the project root
+  static clear () {
+    delete Dependency.__root
+  }
+}
+module.exports = Dependency

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports.saveAll = function (list, options, cb) {
       }
       dep.getVersion(options, next)
     }, function () {
-      fs.writeFile(filename, JSON.stringify(pkg, null, 2), cb)
+      fs.writeFile(Dependency.findNodeModules('package.json'), JSON.stringify(pkg, null, 2), cb)
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -65,6 +65,19 @@ module.exports = function (packages, _options, cb) {
   }, cb)
 }
 
+module.exports.readPackage = function (cb) {
+  const filename = Dependency.findNodeModules('package.json')
+  fs.readFile(filename, (er, buf) => {
+    if (er) { return cb(er) }
+    try {
+      const js = JSON.parse(buf) || {}
+      cb(null, js)
+    } catch (er) {
+      cb(er)
+    }
+  })
+}
+
 // Save all of the dependencies from the list into package.json
 // make this a property of the exported function in to retain backwards
 // compatibility.
@@ -73,10 +86,8 @@ module.exports.saveAll = function (list, options, cb) {
     cb = options
     options = {}
   }
-  const filename = Dependency.findNodeModules('package.json')
-  fs.readFile(filename, (er, buf) => {
+  module.exports.readPackage((er, pkg) => {
     if (er) { return cb(er) }
-    const pkg = JSON.parse(buf) || {}
     pkg.optionalDevDependencies = pkg.optionalDevDependencies || {}
     async.eachSeries(list, function (arg, next) {
       const parts = arg.split('@')

--- a/index.js
+++ b/index.js
@@ -1,10 +1,29 @@
 'use strict'
 
 var assign = require('lodash.assign')
-var eachLimit = require('async').eachLimit
-var spawn = require('cross-spawn')
+var async = require('async')
+var fs = require('fs')
+var Dependency = require('./dependency')
+
+// packages is either array of strings (package names), or an object whose keys
+// are the package names and values are either the version specifier or an array
+// whose first element is the version specifier and whose subsequent elements
+// are tag names.
+
+// examples:
+// ['foo', 'bar@1']: install both foo and bar@1, regardless of _options.tags
+// {foo: "1"}: install foo@1 , regardless of _options.tags
+// {foo: ["1"]}: install foo@1 , regardless of _options.tags
+// {foo: ["1", "a", "b"]}: install foo@1, only if a or b is in _options.tags
 
 module.exports = function (packages, _options, cb) {
+  // normalize packages to array of ['pkg', '@version', ['tag']]
+  if (Array.isArray(packages)) {
+    packages = packages.map(p => new Dependency(p))
+  } else {
+    packages = Object.keys(packages).map(key => new Dependency(key, packages[key]))
+  }
+
   if (typeof _options === 'function') {
     cb = _options
     _options = {}
@@ -12,23 +31,70 @@ module.exports = function (packages, _options, cb) {
 
   cb = cb || function () {}
 
+  // TODO: replace with Object.assign when we have better tests, to remove a
+  // dependency
   var options = assign({
-    stdio: 'inherit'
+    stdio: 'inherit',
+    tags: ['*'],
+    verbose: false
   }, _options)
 
-  eachLimit(packages, 1, function (arg, next) {
-    var pkg = arg.split('@')[0]
-    try {
-      // TODO: Either skip this part if a version has been provided or check the package json version
-      require.resolve(pkg)
-      return next()
-    } catch (err) {
-      var child = spawn('npm', ['install', arg], {stdio: options.stdio})
-      child.once('close', function () {
-        next()
-      })
+  // don't bother to install packages that are already installed or aren't
+  // wanted by tag
+  packages = packages.filter(function (dep) {
+    if (!dep.isInTags(options.tags)) {
+      if (options.verbose) {
+        console.error(dep.name + ': skipping (no matching tag)')
+      }
+      return false
     }
-  }, function (err) {
-    return cb(err)
+    if (dep.isInstalled()) {
+      if (options.verbose) {
+        console.error(dep.name + ': skipping (already installed)')
+      }
+      return false
+    }
+    return true
+  })
+
+  // ideally, you could npm install once with all of the package names, so
+  // that npm could deal with shared dependencies.  Unfortunately, that would
+  // make partial success look like an error.
+  async.eachLimit(packages, 1, function (dep, next) {
+    dep.install(options, next)
+  }, cb)
+}
+
+// Save all of the dependencies from the list into package.json
+// make this a property of the exported function in to retain backwards
+// compatibility.
+module.exports.saveAll = function (list, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = {}
+  }
+  const filename = Dependency.findNodeModules('package.json')
+  fs.readFile(filename, (er, buf) => {
+    if (er) { return cb(er) }
+    const pkg = JSON.parse(buf) || {}
+    pkg.optionalDevDependencies = pkg.optionalDevDependencies || {}
+    async.eachSeries(list, function (arg, next) {
+      const parts = arg.split('@')
+      const name = parts[0]
+      const newVer = parts[1]
+      const prev = pkg.optionalDevDependencies[name]
+      const dep = new Dependency(name, prev)
+      dep.addTags(options.tags)
+      pkg.optionalDevDependencies[name] = dep
+      if (newVer) {
+        dep.version = newVer
+      }
+      if (dep.version !== '*') {
+        return next()
+      }
+      dep.getVersion(options, next)
+    }, function () {
+      fs.writeFile(filename, JSON.stringify(pkg, null, 2), cb)
+    })
   })
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/bcoe/optional-dev-dependency#readme",
   "dependencies": {
+    "async": "^2.1.2",
     "cross-spawn": "^4.0.2",
     "lodash.assign": "^4.2.0",
     "yargs": "^6.2.0"
@@ -41,5 +42,7 @@
     "standard": "^8.4.0",
     "standard-version": "^3.0.0"
   },
-  "engines": { "node" : ">=4" }
+  "engines": {
+    "node": ">=4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "install"
   ],
   "author": "Ben Coe <ben@npmjs.com>",
+  "contributors": [
+    "Joe Hildebrand <joe-github@cursive.net"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/bcoe/npm-optional-dev-dependency/issues"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "bin": "./bin/odd.js",
   "scripts": {
+    "clean": "rimraf .nyc_output/ coverage/",
     "pretest": "standard",
     "test": "nyc ./node_modules/.bin/_mocha --timeout=30000",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
@@ -27,18 +28,18 @@
   },
   "homepage": "https://github.com/bcoe/optional-dev-dependency#readme",
   "dependencies": {
-    "async": "^2.0.0-rc.6",
-    "cross-spawn": "^4.0.0",
-    "lodash.assign": "^4.0.9",
-    "yargs": "^4.7.1"
+    "cross-spawn": "^4.0.2",
+    "lodash.assign": "^4.2.0",
+    "yargs": "^6.2.0"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
+    "chai": "^3.5.0",
     "coveralls": "^2.11.4",
-    "mocha": "^2.3.2",
-    "nyc": "^7.0.0-alpha.5",
-    "rimraf": "^2.4.3",
-    "standard": "^7.1.2",
-    "standard-version": "^2.3.1"
-  }
+    "mocha": "^3.1.2",
+    "nyc": "^8.3.1",
+    "rimraf": "^2.5.4",
+    "standard": "^8.4.0",
+    "standard-version": "^3.0.0"
+  },
+  "engines": { "node" : ">=4" }
 }

--- a/test/dependency.js
+++ b/test/dependency.js
@@ -1,0 +1,128 @@
+'use strict'
+
+/* global describe, it */
+
+const Dependency = require('../dependency')
+const should = require('chai').should()
+const path = require('path')
+const fs = require('fs')
+const tempdir = require('./tempdir')
+
+process.env['npm_config_cache-min'] = '9999999'
+
+describe('dependency', function () {
+  it('can be created', () => {
+    ;(() => new Dependency()).should.throw(TypeError, /must be string/)
+
+    let dep = new Dependency('camelcase')
+    should.exist(dep)
+    dep.name.should.equal('camelcase')
+    dep.version.should.equal('*')
+    dep.tags.should.deep.equal([])
+    JSON.stringify(dep).should.equal('"*"')
+    dep.nameAtVersion.should.equal('camelcase')
+
+    dep = new Dependency('camelcase@^3.0.0')
+    dep.version.should.equal('^3.0.0')
+    JSON.stringify(dep).should.equal('"^3.0.0"')
+    dep.nameAtVersion.should.equal('camelcase@^3.0.0')
+
+    dep = new Dependency('camelcase', '^3.0.0')
+    dep.version.should.equal('^3.0.0')
+    JSON.stringify(dep).should.equal('"^3.0.0"')
+
+    dep = new Dependency('camelcase', ['^3.0.0'])
+    dep.version.should.equal('^3.0.0')
+    dep.tags.should.deep.equal([])
+    JSON.stringify(dep).should.equal('"^3.0.0"')
+
+    dep = new Dependency('camelcase', ['^3.0.0', 'foo', 'bar'])
+    dep.version.should.equal('^3.0.0')
+    dep.tags.should.deep.equal(['foo', 'bar'])
+    JSON.stringify(dep).should.equal('["^3.0.0","foo","bar"]')
+  })
+
+  it('should get version', done => {
+    const dep = new Dependency('camelcase')
+    dep.getVersion((er, ver) => {
+      should.not.exist(er)
+      ver.should.be.a('string')
+      ver.should.have.length.above(0)
+      ver.should.equal(dep.version)
+      done()
+    })
+  })
+
+  it('should add tags without duplicates', () => {
+    const dep = new Dependency('camelcase')
+    dep.tags.should.deep.equal([])
+    dep.addTags()
+    dep.tags.should.deep.equal([])
+    dep.addTags([])
+    dep.tags.should.deep.equal([])
+    dep.addTags('foo')
+    dep.tags.should.deep.equal(['foo'])
+    dep.addTags(['foo', 'bar'])
+    dep.tags.should.deep.equal(['foo', 'bar'])
+    dep.addTags(['foo', 'bar', 'baz', 'baz'])
+    dep.tags.should.deep.equal(['foo', 'bar', 'baz'])
+  })
+
+  it('can check for tags', () => {
+    let dep = new Dependency('camelcase', ['^3.0.0', 'foo', 'bar'])
+    dep.isInTags('foo').should.equal('foo')
+    should.not.exist(dep.isInTags('baz'))
+    dep.isInTags(['baz', 'foo']).should.equal('foo')
+    dep = new Dependency('camelcase')
+    dep.isInTags(['baz', 'foo']).should.equal('*')
+  })
+
+  it('can check for package installation', () => {
+    let dep = new Dependency('async')
+    should.equal(dep.isInstalled(), true)
+    dep = new Dependency('missing-aaabbbcccddd')
+    should.equal(dep.isInstalled(), false)
+  })
+
+  it('can convert to array', () => {
+    ;(() => Dependency.toArray({})).should.throw(TypeError, /not string or array/)
+    ;(() => Dependency.toArray(1)).should.throw(TypeError, /not string or array/)
+    Dependency.toArray().should.deep.equal([])
+    Dependency.toArray('foo').should.deep.equal(['foo'])
+    Dependency.toArray(['foo']).should.deep.equal(['foo'])
+  })
+
+  it('can find node_modules', () => {
+    Dependency.clear()
+    const cwd = process.cwd() // come back here
+
+    process.chdir(__dirname)
+    let nm = Dependency.findNodeModules()
+    nm.should.equal(path.join(__dirname, '..', 'node_modules'))
+    nm = Dependency.findNodeModules('package.json')
+    nm.should.equal(path.join(__dirname, '..', 'package.json'))
+
+    Dependency.clear()
+    process.chdir('/usr')
+    ;(() => Dependency.findNodeModules()).should.throw(Error, /Not in a node package hierarchy/)
+    should.not.exist(Dependency.__root)
+
+    process.chdir(cwd)
+  })
+
+  // do not use => here, or timeout breaks
+  it('can install', function (done) {
+    this.timeout(5000)
+    tempdir((dir, untemp) => {
+      const dep = new Dependency('camelcase')
+      dep.install((er) => {
+        should.not.exist(er)
+        fs.stat(path.join(dir, 'node_modules', 'camelcase'), (er, stats) => {
+          should.not.exist(er)
+          should.equal(stats.isDirectory(), true)
+          untemp()
+        })
+      })
+    }, done)
+  })
+})

--- a/test/tempdir.js
+++ b/test/tempdir.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const rimraf = require('rimraf')
+const fs = require('fs')
+const path = require('path')
+const Dependency = require('../dependency')
+
+const PKG = JSON.stringify({
+  name: 'sample',
+  version: '1.0.0',
+  description: 'Sample with optionalDevDependencies',
+  license: 'ISC',
+  repository: 'none'
+}, null, 2)
+
+let count = 0
+
+// create a temporary directory, populate it with a package.json, cd to it.
+// run the ready function, then return to the previous directory, clean up,
+// and call cb
+module.exports = function (ready, cb) {
+  const cwd = process.cwd()
+  const tmp = path.join(__dirname, '..', 'tmp' + (count++))
+
+  function cleanup (er) {
+    process.chdir(cwd)
+    rimraf(tmp, () => cb(er))
+    Dependency.clear()
+  }
+
+  // clean up in case there was a problem with a previous test
+  // yes...  you wish I had used promises instead.
+  rimraf(tmp, () => {
+    fs.mkdir(tmp, (er) => {
+      if (er) { return cleanup(er) }
+      process.chdir(tmp)
+      fs.writeFile('package.json', PKG, (er) => {
+        if (er) { return cleanup(er) }
+        try {
+          Dependency.clear()
+          ready(tmp, cleanup)
+        } catch (er) {
+          return cleanup(er)
+        }
+      })
+    })
+  })
+}


### PR DESCRIPTION
Sorry for the large-ish PR, but this is functionality that needed to all go together.

new capabilities:

```
optional-dev-dependency -S camelcase  // install camelcase and store it in package.json
optional-dev-dependency --save camelcase -t foo // also save a tag
optional-dev-dependency -t foo // install only packages with the foo tag
```

I also fixed a major bug.  The existing code tended to check for dependencies in the node_modules of _this_ module, rather than the one in which it was executing.

This should be backward-compatible both on the command line as well as the API, so you could do a minor version bump if you liked.
