### PR TITLE
Republish v1.4.0 as 2.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-<a name="1.4.0"></a>
-# [1.4.0](https://github.com/bcoe/optional-dev-dependency/compare/v1.3.0...v1.4.0) (2016-10-25)
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/bcoe/optional-dev-dependency/compare/v1.3.0...v2.0.0) (2016-11-08)
 
 
 ### Bug Fixes
@@ -15,7 +15,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 * install from optionalDevDependencies stanza in package.json ([b9c78d7](https://github.com/bcoe/optional-dev-dependency/commit/b9c78d7))
 
+<a name="1.4.0"></a>
+# [1.4.0](https://github.com/bcoe/optional-dev-dependency/compare/v1.3.0...v1.4.0) (2016-10-25)
 
+Version 1.4 was unpublished on 2016-11-08, in response to bug #16, since it
+broke backward compatibility for old node versions.
 
 <a name="1.3.0"></a>
 # [1.3.0](https://github.com/bcoe/optional-dev-dependency/compare/v1.1.0...v1.3.0) (2016-07-08)

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
   "homepage": "https://github.com/bcoe/optional-dev-dependency#readme",
   "dependencies": {
     "async": "^2.1.2",
-    "cross-spawn": "^4.0.2",
+    "cross-spawn": "^5.0.1",
     "lodash.assign": "^4.2.0",
-    "yargs": "^6.2.0"
+    "yargs": "^6.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.4",
     "mocha": "^3.1.2",
-    "nyc": "^8.3.1",
+    "nyc": "^8.4.0",
     "rimraf": "^2.5.4",
-    "standard": "^8.4.0",
+    "standard": "^8.5.0",
     "standard-version": "^3.0.0"
   },
   "engines": {


### PR DESCRIPTION
Fixes #16.  Still needs an `npm version major` before publishing.