### PR TITLE
Fix path traversal and tests on windows

### DIFF
--- a/dependency.js
+++ b/dependency.js
@@ -141,14 +141,23 @@ class Dependency {
     if (Dependency.__root) {
       return path.join(Dependency.__root, filename)
     }
-    let parts = process.cwd().split(path.sep)
-    while (parts.length > 1) {
-      Dependency.__root = path.sep + path.join.apply(path, parts)
-      if (fs.existsSync(path.join(Dependency.__root, 'package.json'))) {
-        return path.join(Dependency.__root, filename)
+    // start from the current directory
+    Dependency.__root = process.cwd()
+    let hitRoot = false
+    do {
+      // check if we're at the root of the drive
+      hitRoot = Dependency.__root === path.resolve(path.sep)
+      // check the directory for the filename
+      const dir = path.join(Dependency.__root, filename)
+      if (fs.existsSync(dir)) {
+        return dir
       }
-      parts.pop()
+      if (!hitRoot) {
+        // it didn't exist, and we're not at the root so go up one directory
+        Dependency.__root = path.resolve(Dependency.__root, '..')
+      }
     }
+    while (!hitRoot)
     Dependency.clear()
     throw new Error('Not in a node package hierarchy')
   }

--- a/test/dependency.js
+++ b/test/dependency.js
@@ -103,7 +103,9 @@ describe('dependency', function () {
     nm.should.equal(path.join(__dirname, '..', 'package.json'))
 
     Dependency.clear()
-    process.chdir('/usr')
+
+    // go to the root of the current drive
+    process.chdir(path.sep)
     ;(() => Dependency.findNodeModules()).should.throw(Error, /Not in a node package hierarchy/)
     should.not.exist(Dependency.__root)
 


### PR DESCRIPTION
Tried updating to 2.0 but the new stuff doesn't seem to be tested at all on windows.
Kinda odd really since I'm sure this is used quite a bit for optional packages used during tests which don't compile on windows. 

Anyway, before the fix, about 11 tests were failing on windows, and these tweaks seem to fix them all. The main one being the change in dependency.js which gets rid of the code which splits up the path into parts and just relies on the node path library resolving the parent directory.

The first issue was with the path resolving being done in a janky way with concatenating path.sep onto the path. This seems like a nicer approach.

The second issue is in the tests. They use /usr which doesn't exist at all on windows and throws an exception. I changed it to use the root of the drive instead which probably isn't going to be a node module, however, there should probably be something better here than relying on the current state of the tester's env.

There was also an "issue" that I noticed where the root directory was getting ignored as a possible app directory. Not a common use case, but it's valid nonetheless I believe.  This fixes that by using a do/while loop so that it checks it properly.

Additionally, I don't know if it was on purpose, but you can see line 147 used to check for the existence of package.json rather than the file which was being searched for.